### PR TITLE
Expand engine with async persistence and subsystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Cognitive Concept AI Engine
+
+The goal of this project is to build a deterministic reasoning system that
+operates through signal propagation over a knowledge graph.  Concepts are
+explicitly modelled and every inference step is traceable.  The project is
+currently a prototype but it already contains the core building blocks of the
+``Semantic Signal‑Based AI" (SSBAI) architecture.
+
+## Repository layout
+
+```
+ccai/                Python package with the engine
+  core/              concept graph, models and reasoning subsystems
+  io/                persistence helpers (snapshot & write‑ahead log)
+  nlp/               text parser and information extractor
+  cli/               Typer based utilities
+  run.py             interactive command line demo
+graph_data/          saved snapshot and WAL
+knowledge.txt        seed knowledge in a simple text form
+primitives.json      primitive property definitions
+```
+
+## Architecture overview
+
+The engine follows three main workstreams:
+
+1. **Graph & Persistence Layer** – `ConceptGraph` stores all `ConceptNode` objects
+   in memory and persists them using msgpack snapshots plus a WAL in NDJSON
+   format.  `GraphPersistence` handles atomic writes and replaying mutations at
+   startup.
+2. **Reasoning Engine** – the `ReasoningCore` dispatches `Signal` objects to a
+   set of pluggable subsystems.  Current subsystems handle inheritance and
+   relation lookup.  Future work will introduce fuzzy matching, Bayesian
+   updates and contradiction resolution.
+3. **NLP & Knowledge Acquisition** – spaCy is used for parsing text.  The
+   `InformationExtractor` converts dependency parses into concept nodes and
+   relations while `QueryParser` turns user questions into signals.
+
+The full vision includes an expandable ontology, probabilistic reasoning via
+Bayesian updates, conflict detection and rich natural language ingestion using a
+set of heuristic extraction rules.
+
+## Running the demo
+
+The quickest way to experiment is to execute `python -m ccai.run` and interact
+with the chatbot.  Use commands such as `@learn <sentence>` or `@ingest <file>`
+to teach the system new facts.  All data is stored in `graph_data/`.
+
+Developers can also run `python -m ccai.cli --help` for maintenance commands.
+
+### Example session
+
+```bash
+$ python -m ccai.run
+🤖 Initializing AI...
+🧠 Loading Concept Graph from disk...
+✅ AI Ready. Let's chat!
+You> @learn The knife is sharp.
+You> What is a knife?
+- tool
+```
+
+## Further information
+
+A more detailed roadmap and task breakdown can be found in
+[`docs/PROJECT_PLAN.md`](docs/PROJECT_PLAN.md).

--- a/ccai/cli/main.py
+++ b/ccai/cli/main.py
@@ -5,16 +5,18 @@ import typer
 from rich import print, print_json
 
 from ccai.core.graph import ConceptGraph
-from ccai.core.models import ConceptNode
 from ccai.nlp.extractor import InformationExtractor
+from ccai.nlp.primitives import PrimitiveManager
 
 # This CLI is now purely for development and data management.
 app = typer.Typer(help="A CLI tool to manage the CC-AI's knowledge graph.")
 
 # Initialize components needed for the CLI
 STORAGE_DIR = Path("graph_data")
+PRIMITIVES_FILE = Path("primitives.json")
 graph = ConceptGraph(STORAGE_DIR)
-extractor = InformationExtractor(graph)
+primitive_manager = PrimitiveManager(PRIMITIVES_FILE)
+extractor = InformationExtractor(graph, primitive_manager)
 
 @app.callback(invoke_without_command=True)
 def main(ctx: typer.Context):

--- a/ccai/core/graph.py
+++ b/ccai/core/graph.py
@@ -2,8 +2,9 @@
 
 from pathlib import Path
 from typing import Dict, Optional, List
+import time
 
-from ccai.core.models import ConceptNode
+from ccai.core.models import ConceptNode, PropertySpec
 from ccai.io.persistence import GraphPersistence
 
 class ConceptGraph:
@@ -34,6 +35,26 @@ class ConceptGraph:
         self._nodes[node.name] = node
         self._persistence.log_mutation("ADD_NODE", node_data=node.model_dump())
 
+    def update_property(self, node_name: str, category: str, value: str):
+        """Increment property statistics and recalc scores safely."""
+        node = self.get_node(node_name)
+        if not node:
+            return
+        stats = node.property_stats.setdefault(category, {})
+        stats[value] = stats.get(value, 0) + 1
+        total = sum(stats.values())
+        node.properties[category] = [
+            PropertySpec(value=v, score=(c / total if total else 1.0))
+            for v, c in stats.items()
+        ]
+        node.metadata["last_updated"] = time.time()
+        self._persistence.log_mutation(
+            "UPDATE_PROPERTY",
+            node=node_name,
+            category=category,
+            value=value,
+        )
+
     def add_edge(self, src_name: str, relation_type: str, dst_name: str):
         """Adds a new directional edge between two nodes and logs the mutation."""
         source_node = self.get_node(src_name)
@@ -47,9 +68,10 @@ class ConceptGraph:
         # We'll add to the generic 'relations' dict for now.
         if relation_type not in source_node.relations:
             source_node.relations[relation_type] = []
-        
+
         if dst_name not in source_node.relations[relation_type]:
             source_node.relations[relation_type].append(dst_name)
+            source_node.metadata["last_updated"] = time.time()
             self._persistence.log_mutation(
                 "ADD_EDGE", src=src_name, rel=relation_type, dst=dst_name
             )
@@ -57,7 +79,11 @@ class ConceptGraph:
     def save_snapshot(self):
         """Saves the current state of the graph to a snapshot file."""
         self._persistence.save_snapshot(self._nodes)
-        
+
+    def close(self):
+        """Flushes pending WAL entries."""
+        self._persistence.stop()
+
     def _replay_mutations(self, mutations: List[dict]):
         """Applies a list of mutation operations to the current graph state."""
         for mut in mutations:
@@ -72,4 +98,12 @@ class ConceptGraph:
                     if rel not in self._nodes[src].relations:
                         self._nodes[src].relations[rel] = []
                     if dst not in self._nodes[src].relations[rel]:
-                         self._nodes[src].relations[rel].append(dst)
+                        self._nodes[src].relations[rel].append(dst)
+            elif op == "UPDATE_PROPERTY":
+                node = mut.get("node")
+                cat = mut.get("category")
+                val = mut.get("value")
+                if node and cat and val:
+                    self.update_property(node, cat, val)
+
+

--- a/ccai/core/models.py
+++ b/ccai/core/models.py
@@ -35,7 +35,11 @@ class ConceptNode(BaseModel):
     activation: float = 0.0
     priors: Dict[str, float] = Field(default_factory=dict)
     metadata: Dict[str, Any] = Field(
-        default_factory=lambda: {"created": time.time(), "usage": 0}
+        default_factory=lambda: {
+            "created": time.time(),
+            "last_updated": time.time(),
+            "usage": 0,
+        }
     )
 
 class Signal(BaseModel):

--- a/ccai/core/signal_hub.py
+++ b/ccai/core/signal_hub.py
@@ -1,0 +1,29 @@
+"""Priority based queue for managing signals during reasoning."""
+
+from __future__ import annotations
+
+import heapq
+from typing import List, Tuple, Optional
+
+from ccai.core.models import Signal
+
+
+class SignalHub:
+    """A simple priority queue ordered by signal confidence."""
+
+    def __init__(self) -> None:
+        self._queue: List[Tuple[float, int, Signal]] = []
+        self._counter = 0
+
+    def push(self, signal: Signal) -> None:
+        self._counter += 1
+        heapq.heappush(self._queue, (-signal.confidence, self._counter, signal))
+
+    def pop(self) -> Optional[Signal]:
+        if not self._queue:
+            return None
+        _, _, sig = heapq.heappop(self._queue)
+        return sig
+
+    def empty(self) -> bool:
+        return len(self._queue) == 0

--- a/ccai/core/subsystems/bayes.py
+++ b/ccai/core/subsystems/bayes.py
@@ -1,0 +1,25 @@
+"""Subsystem performing simple Bayesian confidence updates."""
+
+from typing import List, Tuple
+
+from ccai.core.models import Signal, ConceptNode
+from ccai.core.subsystems.base import Subsystem
+
+
+class BayesianUpdater(Subsystem):
+    """Updates signal confidence using stored priors on nodes."""
+
+    def evaluate(self, signal: Signal, node: ConceptNode) -> Tuple[float, List[Signal]]:
+        if signal.purpose != "OBSERVE":
+            return 0.0, []
+
+        key = signal.payload.get("relation")
+        if not key:
+            return 0.0, []
+
+        likelihood = node.priors.get(key, 0.5)
+        prior = signal.confidence
+        posterior = likelihood * prior
+        delta = posterior - prior
+        signal.confidence = posterior
+        return delta, []

--- a/ccai/core/subsystems/conflict.py
+++ b/ccai/core/subsystems/conflict.py
@@ -1,0 +1,32 @@
+"""Subsystem detecting contradictory assertions."""
+
+from typing import List, Tuple
+
+from ccai.core.models import Signal, ConceptNode
+from ccai.core.subsystems.base import Subsystem
+
+
+class ConflictResolver(Subsystem):
+    """Looks for direct contradictions when asserting facts."""
+
+    def evaluate(self, signal: Signal, node: ConceptNode) -> Tuple[float, List[Signal]]:
+        if signal.purpose != "ASSERT":
+            return 0.0, []
+
+        relation = signal.payload.get("relation")
+        target = signal.payload.get("target")
+        if not relation or not target:
+            return 0.0, []
+
+        contradictions = []
+        existing = node.relations.get(relation, [])
+        if target not in existing and existing:
+            contradictions.append(existing[0])
+
+        if contradictions:
+            penalty = -1.0
+            objection = signal.model_copy(deep=True)
+            objection.payload = {"objection": f"conflicts with {contradictions[0]}"}
+            return penalty, [objection]
+
+        return 0.0, []

--- a/ccai/core/subsystems/fuzzy.py
+++ b/ccai/core/subsystems/fuzzy.py
@@ -1,0 +1,25 @@
+"""Subsystem implementing fuzzy property matching."""
+
+from difflib import SequenceMatcher
+from typing import List, Tuple
+
+from ccai.core.models import Signal, ConceptNode
+from ccai.core.subsystems.base import Subsystem
+
+
+class FuzzyMatch(Subsystem):
+    """Adjusts signal confidence based on approximate property matches."""
+
+    def evaluate(self, signal: Signal, node: ConceptNode) -> Tuple[float, List[Signal]]:
+        if signal.purpose != "VERIFY" or signal.payload.get("relation") != "has_property":
+            return 0.0, []
+
+        target = signal.payload.get("target")
+        best = 0.0
+        for prop_list in node.properties.values():
+            for spec in prop_list:
+                if isinstance(spec.value, str):
+                    sim = SequenceMatcher(None, target, spec.value).ratio()
+                    best = max(best, sim)
+        penalty = - (1 - best)
+        return penalty, []

--- a/ccai/io/persistence.py
+++ b/ccai/io/persistence.py
@@ -5,6 +5,8 @@ import os
 import time
 from pathlib import Path
 from typing import Dict, List, Any, Tuple
+from threading import Thread, Event
+from queue import Queue, Empty
 
 import msgpack
 from ccai.core.models import ConceptNode
@@ -16,9 +18,15 @@ class GraphPersistence:
         self.storage_path = storage_path
         self.snapshot_file = storage_path / "snapshot.msgpack"
         self.wal_file = storage_path / "wal.ndjson"
-        
+
         # Ensure the storage directory exists
         self.storage_path.mkdir(parents=True, exist_ok=True)
+
+        # Queue and background thread for async WAL writing
+        self._queue: Queue = Queue()
+        self._stop_event = Event()
+        self._worker = Thread(target=self._process_queue, daemon=True)
+        self._worker.start()
 
     def save_snapshot(self, nodes: Dict[str, ConceptNode]):
         """Saves the entire graph to a compressed msgpack file atomically."""
@@ -59,8 +67,30 @@ class GraphPersistence:
             "op": op,
             **data
         }
-        with open(self.wal_file, "a") as f:
-            f.write(json.dumps(log_entry) + "\n")
+        self._queue.put(log_entry)
+
+    def _process_queue(self):
+        """Background worker that writes queued mutations to disk."""
+        while not self._stop_event.is_set():
+            try:
+                entry = self._queue.get(timeout=0.1)
+            except Empty:
+                continue
+            with open(self.wal_file, "a") as f:
+                f.write(json.dumps(entry) + "\n")
+            self._queue.task_done()
+
+    def stop(self):
+        """Stops the background writer and flushes remaining entries."""
+        self._stop_event.set()
+        self._worker.join()
+        while True:
+            try:
+                entry = self._queue.get_nowait()
+            except Empty:
+                break
+            with open(self.wal_file, "a") as f:
+                f.write(json.dumps(entry) + "\n")
 
     def load_mutations_after(self, timestamp: float) -> List[Dict[str, Any]]:
         """Loads all mutations from the WAL that occurred after the given timestamp."""

--- a/ccai/run.py
+++ b/ccai/run.py
@@ -13,6 +13,9 @@ from ccai.nlp.primitives import PrimitiveManager
 from ccai.core.reasoning import ReasoningCore
 from ccai.core.subsystems.inheritance import InheritanceResolver
 from ccai.core.subsystems.relation import RelationResolver
+from ccai.core.subsystems.fuzzy import FuzzyMatch
+from ccai.core.subsystems.bayes import BayesianUpdater
+from ccai.core.subsystems.conflict import ConflictResolver
 
 def run_chat_session():
     """Initializes all AI components and starts the interactive chat loop."""
@@ -29,7 +32,10 @@ def run_chat_session():
     
     subsystems = [
         InheritanceResolver(),
-        RelationResolver(graph=graph)
+        RelationResolver(graph=graph),
+        FuzzyMatch(),
+        BayesianUpdater(),
+        ConflictResolver(),
     ]
     reasoning_core = ReasoningCore(graph, subsystems)
     

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -1,0 +1,43 @@
+# Project Plan
+
+This document outlines the next development steps for advancing the
+Cognitive Concept AI (CCAI) engine towards a robust prototype.
+
+## 1. Graph & Persistence Layer
+- Implement asynchronous WAL writing so reasoning is never blocked by disk I/O.
+- Expand `ConceptNode` with additional metadata fields such as `last_updated` and usage counters.
+- Create `ConceptGraph` helper methods for updating property statistics and edges safely.
+
+## 2. Reasoning Engine
+- Add a priority based `SignalHub` to manage propagation order.
+- Implement the following subsystems:
+  - **FuzzyMatch** – computes similarity between property values and adjusts
+    signal confidence accordingly.
+  - **BayesianUpdater** – updates belief scores using priors on nodes whenever
+    an observation signal is processed.
+  - **ConflictResolver** – detects contradictory assertions and issues
+    objection signals.
+- Extend `ReasoningCore` to halt processing when signal confidence drops below
+  a threshold or the queue becomes empty.
+
+## 3. NLP & Knowledge Acquisition
+- Configure spaCy pipeline loading in `InformationExtractor` and `QueryParser`.
+- Develop additional extraction rules for agent–action–object phrases and for
+  capturing purpose relations ("used for").
+- Build a small suite of unit tests ensuring that text ingestion creates the
+  expected nodes and relations.
+
+## 4. Tooling and Documentation
+- Fix the CLI initialisation bug (missing `PrimitiveManager`).
+- Provide examples in the README demonstrating learning and querying.
+- Expand documentation with usage guides and API references as modules
+  stabilise.
+
+### Progress
+- Async WAL writer implemented via background thread.
+- Added `last_updated` metadata and safe property helpers in `ConceptGraph`.
+- Introduced `SignalHub` and three new reasoning subsystems.
+- CLI now correctly initialises `PrimitiveManager`.
+
+These items are intended as a starting point and can be tackled in parallel
+across the three main workstreams.

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from ccai.core.graph import ConceptGraph
+from ccai.nlp.extractor import InformationExtractor
+from ccai.nlp.primitives import PrimitiveManager
+
+
+def test_ingest_creates_nodes(tmp_path):
+    graph = ConceptGraph(tmp_path)
+    pm = PrimitiveManager(Path("primitives.json"))
+    extractor = InformationExtractor(graph, pm)
+
+    extractor.ingest_text("A knife is a tool.")
+
+    assert graph.get_node("knife") is not None
+    knife = graph.get_node("knife")
+    assert "is_a" in knife.relations


### PR DESCRIPTION
## Summary
- implement async WAL writing and metadata updates
- add property helpers and new SignalHub queue
- create FuzzyMatch, BayesianUpdater and ConflictResolver
- fix CLI primitive manager init
- provide README example and update project plan
- add basic ingestion test

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814f01a9d88330aaa89e95ffc39655