### PR TITLE
Improve setup docs and deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,16 @@ set of heuristic extraction rules.
 
 ## Running the demo
 
-The quickest way to experiment is to execute `python -m ccai.run` and interact
-with the chatbot.  Use commands such as `@learn <sentence>` or `@ingest <file>`
-to teach the system new facts.  All data is stored in `graph_data/`.
+Install the package in editable mode and download the small spaCy model first:
+
+```bash
+pip install -e .
+python -m spacy download en_core_web_sm
+```
+
+Then run the interactive demo via `python -m ccai.run` and chat with the bot.
+Use commands such as `@learn <sentence>` or `@ingest <file>` to teach new
+facts.  All data is stored in `graph_data/`.
 
 Developers can also run `python -m ccai.cli --help` for maintenance commands.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ spacy = ">=3.7"
 fastapi = ">=0.111"
 uvicorn = {extras = ["standard"], version = "^0.35.0"}
 msgpack = ">=1.0"
+rich = ">=14.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Summary
- require `rich` in poetry dependencies
- document how to install dependencies and spaCy model in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815a0200788330a6b7d31d69c0bf5a